### PR TITLE
Save values via background

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Save Your Type",
   "description": "Save your almost all typed text to local storage.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "action": { "default_popup": "index.html" },
   "content_scripts": [
     {

--- a/src/background.ts
+++ b/src/background.ts
@@ -8,13 +8,32 @@ const HISTORIES_KEY = "save-your-type";
 
 chrome.runtime.onMessage.addListener(
   async (message: { type: string; value: Store }) => {
-    switch (message.type) {
+    const { type, value: newValue } = message;
+    switch (type) {
       case HISTORIES_KEY: {
-        try {
-          const histories = await getHistories();
-          await setHistories([...histories, message.value]);
-        } catch (error) {
-          console.error("Error accessing storage:", error);
+        let histories = await getHistories();
+        let value = histories ? [...histories, newValue] : [newValue];
+        let attempts = 0;
+
+        while (attempts < 5) {
+          try {
+            await setHistories(value);
+            return;
+          } catch (error) {
+            if (!(error instanceof Error)) {
+              return;
+            }
+            if (error.message === "Storage limit exceeded") {
+              console.warn("Storage limit exceeded. Removing oldest values...");
+              await removeOldHistories();
+              histories = await getHistories();
+              value = histories ? [...histories, newValue] : [newValue];
+            } else {
+              console.error("Failed to set storage:", error);
+              return;
+            }
+          }
+          attempts++;
         }
 
         break;
@@ -52,4 +71,15 @@ const setHistories = (value: Store[]) => {
       }
     });
   });
+};
+
+const removeOldHistories = async () => {
+  const histories = await getHistories();
+  if (!histories || histories.length === 0) {
+    return;
+  }
+  histories.shift();
+  histories.shift();
+  histories.shift();
+  await setHistories(histories);
 };

--- a/src/background.ts
+++ b/src/background.ts
@@ -11,8 +11,8 @@ chrome.runtime.onMessage.addListener(
     switch (message.type) {
       case HISTORIES_KEY: {
         try {
-          const histories = await getStorage();
-          await setStorage([...histories, message.value]);
+          const histories = await getHistories();
+          await setHistories([...histories, message.value]);
         } catch (error) {
           console.error("Error accessing storage:", error);
         }
@@ -27,7 +27,7 @@ chrome.runtime.onMessage.addListener(
   }
 );
 
-const getStorage = (): Promise<Store[]> => {
+const getHistories = (): Promise<Store[]> => {
   return new Promise((resolve, reject) => {
     chrome.storage.local.get(
       HISTORIES_KEY,
@@ -42,7 +42,7 @@ const getStorage = (): Promise<Store[]> => {
   });
 };
 
-const setStorage = (value: Store[]) => {
+const setHistories = (value: Store[]) => {
   return new Promise((resolve, reject) => {
     chrome.storage.local.set({ [HISTORIES_KEY]: value }, () => {
       if (chrome.runtime.lastError) {

--- a/src/background.ts
+++ b/src/background.ts
@@ -30,10 +30,10 @@ chrome.runtime.onMessage.addListener(
               value = histories ? [...histories, newValue] : [newValue];
             } else {
               console.error("Failed to set storage:", error);
-              return;
             }
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+            attempts++;
           }
-          attempts++;
         }
 
         break;

--- a/src/store/useChromeStorageHistories.ts
+++ b/src/store/useChromeStorageHistories.ts
@@ -45,7 +45,7 @@ export const useChromeStorageHistories = () => {
   );
 
   const sendValueToBackground = useCallback((value: Store) => {
-    chrome.runtime.sendMessage({ type: "save-your-type", value });
+    chrome.runtime.sendMessage({ type: STORAGE_KEY, value });
   }, []);
 
   return {

--- a/src/store/useChromeStorageHistories.ts
+++ b/src/store/useChromeStorageHistories.ts
@@ -85,5 +85,15 @@ export const useChromeStorageHistories = () => {
     [getStorage, setStorage]
   );
 
-  return { getStorage, pushValue, removeAllValue, removeValuesBefore };
+  const sendValueToBackground = useCallback((value: Store) => {
+    chrome.runtime.sendMessage({ type: "save-your-type", value });
+  }, []);
+
+  return {
+    getStorage,
+    pushValue,
+    removeAllValue,
+    removeValuesBefore,
+    sendValueToBackground,
+  };
 };

--- a/src/store/useChromeStorageHistories.ts
+++ b/src/store/useChromeStorageHistories.ts
@@ -24,47 +24,6 @@ export const useChromeStorageHistories = () => {
     });
   }, []);
 
-  const RemoveOldestValues = useCallback(async () => {
-    const store = await getStorage();
-    if (!store || store.length === 0) {
-      return;
-    }
-    store.shift();
-    await setStorage(store);
-  }, [getStorage, setStorage]);
-
-  const pushValue = useCallback(
-    async (newValue: Store) => {
-      let store = await getStorage();
-      let value = store ? [...store, newValue] : [newValue];
-
-      let attempts = 0;
-      while (attempts < 5) {
-        try {
-          await setStorage(value);
-          return;
-        } catch (error) {
-          if (!(error instanceof Error)) {
-            return;
-          }
-          if (error.message === "Storage limit exceeded") {
-            console.warn("Storage limit exceeded. Removing oldest values...");
-            await RemoveOldestValues();
-            store = await getStorage();
-            value = store ? [...store, newValue] : [newValue];
-          } else {
-            console.error("Failed to set storage:", error);
-            return;
-          }
-        }
-        attempts++;
-      }
-
-      console.error("Failed to push value after multiple attempts.");
-    },
-    [RemoveOldestValues, getStorage, setStorage]
-  );
-
   const removeAllValue = () => {
     chrome.storage.local.remove(STORAGE_KEY);
   };
@@ -91,7 +50,6 @@ export const useChromeStorageHistories = () => {
 
   return {
     getStorage,
-    pushValue,
     removeAllValue,
     removeValuesBefore,
     sendValueToBackground,

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -8,14 +8,14 @@ export const useStore = () => {
   const {
     settings: { debounceTimeMs },
   } = useChromeStorageSettings();
-  const { pushValue } = useChromeStorageHistories();
+  const { sendValueToBackground } = useChromeStorageHistories();
 
   const [isReady, cancel] = useDebounce(
     async () => {
       if (!tmpValue) {
         return;
       }
-      pushValue(tmpValue);
+      sendValueToBackground(tmpValue);
       setTmpValue(undefined);
     },
     debounceTimeMs,
@@ -44,7 +44,7 @@ export const useStore = () => {
       datetime: new Date().toISOString(),
       url: window.location.href,
     };
-    pushValue(value);
+    sendValueToBackground(value);
   };
 
   const pushValueImmediately = () => {
@@ -52,7 +52,7 @@ export const useStore = () => {
       return;
     }
     // send background because async function is not allowed in beforeunload event
-    chrome.runtime.sendMessage({ type: "save-your-type", value: tmpValue });
+    sendValueToBackground(tmpValue);
   };
 
   return {


### PR DESCRIPTION
- 保存を全てbackground経由にする
  -もともと onbeforeunloadのみやっていたが、一貫性を出すために全てbackgroundにする
    - onbeforeunloadは同期イベントしか受け付けられないため
- 書き込み自体は軽量な処理なので、backgroundにしてもしなくてもほぼパフォーマンスが変わることはなさそう